### PR TITLE
feat: add config read writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *$py.class
 
 .env
+.idea/

--- a/lib/config/base_config_read_writer.py
+++ b/lib/config/base_config_read_writer.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+from lib.config.config import Config
+
+
+class AbstractConfigReadWriter(ABC):
+    @abstractmethod
+    def read(self) -> Config:
+        raise NotImplementedError("not implemented")
+
+    @abstractmethod
+    def write(self, config: Config) -> bool:
+        raise NotImplementedError("not implemented")
+

--- a/lib/config/config.py
+++ b/lib/config/config.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+
+class Config:
+    FB_GROUP_ID: str
+    FB_ACCESS_TOKEN: str
+
+    FB_APP_ID: str
+    FB_APP_SECRET: str
+
+    SMTP_USER: str
+    SMTP_PASS: str
+
+    TOP_K: int
+    FIRST_WORDS: int
+
+    @classmethod
+    def of(cls, **kwargs) -> Config:
+        c = cls()
+        c.FB_GROUP_ID = kwargs.get("FB_GROUP_ID")
+        c.FB_ACCESS_TOKEN = kwargs.get("FB_ACCESS_TOKEN")
+        c.FB_APP_ID = kwargs.get("FB_APP_ID")
+        c.FB_APP_SECRET = kwargs.get("FB_APP_SECRET")
+        c.SMTP_USER = kwargs.get("SMTP_USER")
+        c.SMTP_PASS = kwargs.get("SMTP_PASS")
+
+        c.TOP_K = int(kwargs.get("TOP_K", "10"))
+        c.FIRST_WORDS = int(kwargs.get("TOP_K", "10"))
+        return c
+
+    def __eq__(self, o: object) -> bool:
+        if not isinstance(o, Config):
+            return False
+
+        return (
+            self.FB_GROUP_ID == o.FB_GROUP_ID
+            and self.FB_ACCESS_TOKEN == o.FB_ACCESS_TOKEN
+            and self.FB_APP_ID == o.FB_APP_ID
+            and self.FB_APP_SECRET == o.FB_APP_SECRET
+            and self.SMTP_USER == o.SMTP_USER
+            and self.SMTP_PASS == o.SMTP_PASS
+            and self.TOP_K == o.TOP_K
+            and self.FIRST_WORDS == o.FIRST_WORDS
+        )
+
+    def __repr__(self) -> str:
+        return f"""Config(
+    FB_GROUP_ID: {self.FB_GROUP_ID}
+    FB_ACCESS_TOKEN: {self.FB_ACCESS_TOKEN}
+    FB_APP_ID: {self.FB_APP_ID}
+    FB_APP_SECRET: {self.FB_APP_SECRET}
+    SMTP_USER: {self.SMTP_USER}
+    SMTP_PASS: {self.SMTP_PASS}
+    TOP_K: {self.TOP_K}
+    FIRST_WORDS: {self.FIRST_WORDS}
+)"""
+

--- a/lib/config/dot_env_read_writer.py
+++ b/lib/config/dot_env_read_writer.py
@@ -1,0 +1,65 @@
+import logging
+from typing import Tuple
+
+import dotenv
+
+from lib.config.base_config_read_writer import AbstractConfigReadWriter
+from lib.config.config import Config
+
+
+class DotEnvReadWriter(AbstractConfigReadWriter):
+    def __init__(self, env_file: str):
+        self.env_file = env_file
+
+    def read(self) -> Config:
+        """Returns Config from self.env_file"""
+        dotenv_values = dotenv.dotenv_values(self.env_file)
+        return Config.of(**dotenv_values)
+
+    @staticmethod
+    def log_on_fail(dotenv_result: Tuple[bool, str, str]) -> bool:
+        ok, key, val = dotenv_result
+
+        if not ok:
+            logging.warning(
+                "failed to update .env value (key = %s, value = %s)", key, val
+            )
+
+        return ok
+
+    def write(self, config: Config) -> bool:
+        """Writes Config to .env and returns True if all write succeed"""
+        ok = True
+
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FB_GROUP_ID", config.FB_GROUP_ID)
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FB_GROUP_ID", config.FB_GROUP_ID)
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FB_ACCESS_TOKEN", config.FB_ACCESS_TOKEN)
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FB_APP_ID", config.FB_APP_ID)
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FB_APP_SECRET", config.FB_APP_SECRET)
+        )
+
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "SMTP_USER", config.SMTP_USER)
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "SMTP_PASS", config.SMTP_PASS)
+        )
+
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "TOP_K", str(config.TOP_K))
+        )
+        ok &= self.log_on_fail(
+            dotenv.set_key(self.env_file, "FIRST_WORDS", str(config.FIRST_WORDS))
+        )
+
+        return ok
+

--- a/lib/config/dot_env_read_writer_test.py
+++ b/lib/config/dot_env_read_writer_test.py
@@ -1,0 +1,66 @@
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from lib.config.config import Config
+from lib.config.dot_env_read_writer import DotEnvReadWriter
+
+
+class TestDotEnvReadWriter(TestCase):
+    def setUp(self) -> None:
+        self.env_file_content = """
+    FB_GROUP_ID=123
+    FB_ACCESS_TOKEN="abc"
+    FB_APP_ID=123
+    FB_APP_SECRET="123"
+    SMTP_USER="smtp_user"
+    SMTP_PASS="smtp_pass"
+    TOP_K=10
+    FIRST_WORDS=10
+"""
+        self._temp_dir = tempfile.mkdtemp()
+        self.env_file_path = os.path.join(self._temp_dir, ".env")
+
+        with open(self.env_file_path, "w") as file:
+            file.write(self.env_file_content)
+
+    def tearDown(self) -> None:
+        """Deletes a temporary directory"""
+        shutil.rmtree(self._temp_dir)
+
+    @staticmethod
+    def _get_config() -> Config:
+        config = Config()
+        config.FB_GROUP_ID = "123"
+        config.FB_ACCESS_TOKEN = "abc"
+        config.FB_APP_ID = "123"
+        config.FB_APP_SECRET = "123"
+        config.SMTP_USER = "smtp_user"
+        config.SMTP_PASS = "smtp_pass"
+        config.TOP_K = 10
+        config.FIRST_WORDS = 10
+
+        return config
+
+    def test_read(self):
+        env_rw = DotEnvReadWriter(self.env_file_path)
+        config = env_rw.read()
+
+        expected = self._get_config()
+
+        self.assertEqual(config, expected)
+
+    def test_write(self):
+        env_rw = DotEnvReadWriter(self.env_file_path)
+        config = env_rw.read()
+
+        config.FB_ACCESS_TOKEN = "I changed FB_ACCESS_TOKEN"
+
+        self.assertTrue(env_rw.write(config))
+
+        new_env_rw = DotEnvReadWriter(self.env_file_path)
+        new_config = new_env_rw.read()
+
+        self.assertEqual(new_config, config)
+

--- a/static/constants.py
+++ b/static/constants.py
@@ -1,21 +1,27 @@
-import os
-from dotenv import load_dotenv
+from dotenv import find_dotenv
 
-load_dotenv()
+from lib.config.dot_env_read_writer import DotEnvReadWriter
 
-GROUP_ID        = os.getenv("FB_GROUP_ID")
-ACCESS_TOKEN    = os.getenv("FB_ACCESS_TOKEN")
-SMTP_USER       = os.getenv("SMTP_USER")
-SMTP_PASS       = os.getenv("SMTP_PASS")
+config_read_writer = DotEnvReadWriter(find_dotenv())
+
+config = config_read_writer.read()
+
+GROUP_ID = config.FB_GROUP_ID
+ACCESS_TOKEN = config.FB_ACCESS_TOKEN
+SMTP_USER = config.SMTP_USER
+SMTP_PASS = config.SMTP_PASS
 
 BASE_URL = f"https://graph.facebook.com/v7.0/{GROUP_ID}/feed?"
 TAIL_URL = f"fields=message%2Creactions.summary(total_count)%2Ccomments.summary(total_count)%2Cpermalink_url%2Cshares%2Cupdated_time%2Cattachments{{media}}&access_token={ACCESS_TOKEN}"
 
-TOP_K       = int(os.getenv("TOP_K"))
-FIRST_WORDS = int(os.getenv("FIRST_WORDS"))
+TOP_K = config.TOP_K
+FIRST_WORDS = config.FIRST_WORDS
 
-HEAD_LOGO   = "https://cdn-images-1.medium.com/max/1600/0*LDGNE2IRJOFFcJ3s.png"
-HEAD_IMAGE  = "https://github.com/deep-diver/fb-group-post-fetcher/blob/master/static/images/tfkr-logo-white-background.png?raw=true"
-HEAD_ARTICLE= "텐서플로우 한국 커뮤니티 (TFUG Korea) 에서 발행하는 뉴스레터 입니다. 지난 몇 일간 게시된 글 중, 좋아요/공유/댓글 개수를 산정하여 TOP 10으로 랭킹된 것들을 모아서 보내드립니다. 자세한 내용은 하단을 참고해 주시고, 더 많은 게시글을 보고 싶으시다면 커뮤니티 방문하기 버튼을 클릭해 주세요!"
+HEAD_LOGO = "https://cdn-images-1.medium.com/max/1600/0*LDGNE2IRJOFFcJ3s.png"
+HEAD_IMAGE = "https://github.com/deep-diver/fb-group-post-fetcher/blob/master/static/images/tfkr-logo-white-background.png?raw=true"
+HEAD_ARTICLE = "텐서플로우 한국 커뮤니티 (TFUG Korea) 에서 발행하는 뉴스레터 입니다. 지난 몇 일간 게시된 글 중, 좋아요/공유/댓글 개수를 산정하여 TOP 10으로 랭킹된 것들을 모아서 보내드립니다. 자세한 내용은 하단을 참고해 주시고, 더 많은 게시글을 보고 싶으시다면 커뮤니티 방문하기 버튼을 클릭해 주세요!"
 HEAD_BUTTON_TITLE = "커뮤니티 방문하기"
-BOTTOM_ARTICLE= "현재 시범 운영 중입니다"
+BOTTOM_ARTICLE = "현재 시범 운영 중입니다"
+
+if __name__ == "__main__":
+    print(config)


### PR DESCRIPTION

- Create a `Config` object to hold the application context.
- Create a base class for ReadWriter so that it can store a new value.
- Later `YamlReadWriter` or `ProtoReadWriter` can extend and it can be swapped.



#5 

